### PR TITLE
feat: Rename include/exclude teams to include/exclude projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following dependencies are required to run the program:
 ## 🛠 Usage
 To run the main script, change to the current directory of the script, then run:
 
-`python version2.py --output-file "<filename.json>" --temp-dir "<temp.dir>" --include-team <teamname>`
+`python version2.py --output-file "<filename.json>" --temp-dir "<temp.dir>" --include-project <project name>`
 
 See the `--help` menu for full list of filter functionality.
 

--- a/current-implemented-CLI.md
+++ b/current-implemented-CLI.md
@@ -5,7 +5,7 @@
 - `output-file` - Define the filename and location of the output file
 - `temp-dir` - The temporary directory to write JSON response files
 
-- `include-team` - Include a team to the query
+- `include-project` - Include a project to the query
 - `include-user` - Include a user to the query
 
 
@@ -15,12 +15,14 @@
 - `include-organization` - Include specific org to a query
 - `include-organization-repository` - Include specific org/repo to the query
 - `include-label` - Include a specific label to the query
+- `include-team` - Include a specific team to the query
 
-- `exclude-team` - Exclude specific team from the output
+- `exclude-project` - Exclude a project from the output
 - `exclude-user` - Exclude specific user from the output
 - `exclude-repository` - Exclude specific repo from the output
 - `exclude-organization` - Exclude specific org from the output
 - `exclude-organization-repository` - Exclude specific org/repo from the output
 - `exclude-label` - Exclude issues with specific label from the output
+- `exclude-team` - Exclude specific team from the output
 
 - `publish-board` - Copy output of script to a common board in GitHub by using the GH API

--- a/src/queryFilter.py
+++ b/src/queryFilter.py
@@ -8,40 +8,45 @@ It is used in the Version2Query class to filter projects based on user input.
 from rich import print
 
 class QueryFilter:
+  # the def method takes in a list of strings for each filter type
   def __init__(
     self,
-    include_teams:list[str]=None,
+    include_projects:list[str]=None,
     include_users:list[str]=None,
     include_repositories:list[str]=None,
     include_organizations:list[str]=None,
     include_organization_repositories:list[str]=None,
     include_labels:list[str]=None,
-    exclude_teams:list[str]=None,
+    include_teams:list[str]=None,
+    exclude_projects:list[str]=None,
     exclude_users:list[str]=None,
     exclude_repositories:list[str]=None,
     exclude_organizations:list[str]=None,
     exclude_organization_repositories:list[str]=None,
-    exclude_label:list[str]=None
+    exclude_label:list[str]=None,
+    exclude_teams:list[str]=None
   ):
-    self.include_teams:list[str]                     = include_teams
+    self.include_projects:list[str]                  = include_projects
     self.include_users:list[str]                     = include_users
     self.include_repositories:list[str]              = include_repositories
     self.include_organizations:list[str]             = include_organizations
     self.include_organization_repositories:list[str] = include_organization_repositories
     self.include_labels:list[str]                    = include_labels
-    self.exclude_teams:list[str]                     = exclude_teams
+    self.include_teams:list[str]                     = include_teams
+    self.exclude_projects:list[str]                  = exclude_projects
     self.exclude_users:list[str]                     = exclude_users
     self.exclude_repositories:list[str]              = exclude_repositories
     self.exclude_organizations:list[str]             = exclude_organizations
     self.exclude_organization_repositories:list[str] = exclude_organization_repositories
     self.exclude_label:list[str]                     = exclude_label
+    self.exclude_teams:list[str]                     = exclude_teams
 
   @property
-  def include_teams(self) -> list[str]:
-    return self._include_teams
-  @include_teams.setter
-  def include_teams(self, value:list[str]) -> None:
-    self._include_teams=value
+  def include_projects(self) -> list[str]:
+    return self._include_projects
+  @include_projects.setter
+  def include_projects(self, value:list[str]) -> None:
+    self._include_projects=value
 
   @property
   def include_users(self) -> list[str]:
@@ -79,11 +84,18 @@ class QueryFilter:
     self._include_labels=value
 
   @property
-  def exclude_teams(self) -> list[str]:
-    return self._exclude_teams
-  @exclude_teams.setter
-  def exclude_teams(self, value:list[str]) -> None:
-    self._exclude_teams=value
+  def include_teams(self) -> list[str]:
+    return self._include_teams
+  @include_teams.setter
+  def include_teams(self, value:list[str]) -> None:
+    self._include_teams=value
+
+  @property
+  def exclude_projects(self) -> list[str]:
+    return self._exclude_projects
+  @exclude_projects.setter
+  def exclude_projects(self, value:list[str]) -> None:
+    self._exclude_projects=value
 
   @property
   def exclude_users(self) -> list[str]:
@@ -120,50 +132,63 @@ class QueryFilter:
   def exclude_label(self, value:list[str]) -> None:
     self._exclude_label=value
 
+  @property
+  def exclude_teams(self) -> list[str]:
+    return self._exclude_teams
+  @exclude_teams.setter
+  def exclude_teams(self, value:list[str]) -> None:
+    self._exclude_teams=value
+
   def print_filters(self) -> None:
     """Print the filters for debugging purposes."""
     print(f"[bold green]Filters:[/bold green]")
-    print(f"Include Teams: {self.include_teams}")
+    print(f"Include Projects: {self.include_projects}")
     print(f"Include Users: {self.include_users}")
     print(f"Include Repositories: {self.include_repositories}")
     print(f"Include Organizations: {self.include_organizations}")
     print(f"Include Organization Repositories: {self.include_organization_repositories}")
     print(f"Include Labels: {self.include_labels}")
-    print(f"Exclude Teams: {self.exclude_teams}")
+    print(f"Include Teams: {self.include_teams}")
+    print(f"Exclude Projects: {self.exclude_projects}")
     print(f"Exclude Users: {self.exclude_users}")
     print(f"Exclude Repositories: {self.exclude_repositories}")
     print(f"Exclude Organizations: {self.exclude_organizations}")
     print(f"Exclude Organization Repositories: {self.exclude_organization_repositories}")
     print(f"Exclude Label: {self.exclude_label}")
+    print(f"Exclude Teams: {self.exclude_teams}")
 
   def get_filters(self) -> dict[str,list[str]]:
     """Get the filters as a dictionary."""
     return {
-      "include_teams":                     self.include_teams,
+      "include_projects":                  self.include_projects,
       "include_users":                     self.include_users,
       "include_repositories":              self.include_repositories,
       "include_organizations":             self.include_organizations,
       "include_organization_repositories": self.include_organization_repositories,
       "include_labels":                    self.include_labels,
-      "exclude_teams":                     self.exclude_teams,
+      "include_teams":                     self.include_teams,
+      "exclude_projects":                  self.exclude_projects,
       "exclude_users":                     self.exclude_users,
       "exclude_repositories":              self.exclude_repositories,
       "exclude_organizations":             self.exclude_organizations,
       "exclude_organization_repositories": self.exclude_organization_repositories,
-      "exclude_label":                     self.exclude_label
+      "exclude_label":                     self.exclude_label,
+      "exclude_teams":                     self.exclude_teams
     }
 
   def set_filters_from_dict(self, filters:dict[str,list[str]]):
     """Set the filters from a dictionary."""
-    self.include_teams                     = filters.get("include_teams", [])
+    self.include_projects                  = filters.get("include_projects", [])
     self.include_users                     = filters.get("include_users", [])
     self.include_repositories              = filters.get("include_repositories", [])
     self.include_organizations             = filters.get("include_organizations", [])
     self.include_organization_repositories = filters.get("include_organization_repositories", [])
     self.include_labels                    = filters.get("include_labels", [])
-    self.exclude_teams                     = filters.get("exclude_teams", [])
+    self.include_teams                     = filters.get("include_teams", [])
+    self.exclude_projects                  = filters.get("exclude_projects", [])
     self.exclude_users                     = filters.get("exclude_users", [])
     self.exclude_repositories              = filters.get("exclude_repositories", [])
     self.exclude_organizations             = filters.get("exclude_organizations", [])
     self.exclude_organization_repositories = filters.get("exclude_organization_repositories", [])
     self.exclude_label                     = filters.get("exclude_label", [])
+    self.exclude_teams                     = filters.get("exclude_teams", [])

--- a/src/version2config.py
+++ b/src/version2config.py
@@ -161,7 +161,7 @@ class VersionTwoConfig:
 
         self.output_file = parsed_args.output_file
         self.temp_dir = parsed_args.temp_dir
-        self.project = parsed_args.include_project
+        self.include_project = parsed_args.include_project
         self.include_user = parsed_args.include_user
         self.include_repository = parsed_args.include_repository
         self.include_organization = parsed_args.include_organization

--- a/src/version2config.py
+++ b/src/version2config.py
@@ -38,11 +38,11 @@ class VersionTwoConfig:
         )
 
         parser.add_argument(
-            "--include-team",
-            dest="include_team",
+            "--include-project",
+            dest="include_project",
             action="append",
             type=str,
-            help="Include provided teams in the output"
+            help="Include project names like [value] in the output"
         )
 
         parser.add_argument(
@@ -86,11 +86,19 @@ class VersionTwoConfig:
         )
 
         parser.add_argument(
-            "--exclude-team",
-            dest="exclude_team",
+            "--include-team",
+            dest="include_team",
             action="append",
             type=str,
-            help="Exclude provided teams in the output"
+            help="Include all issues and PRs from the specified team"
+        )
+
+        parser.add_argument(
+            "--exclude-project",
+            dest="exclude_project",
+            action="append",
+            type=str,
+            help="Exclude project names like [value] in the output"
         )
 
         parser.add_argument(
@@ -135,6 +143,14 @@ class VersionTwoConfig:
         )
 
         parser.add_argument(
+            "--exclude-team",
+            dest="exclude_team",
+            action="append",
+            type=str,
+            help="Exclude all issues and PRs from the specified team"
+        )
+
+        parser.add_argument(
             "--publish-board",
             dest="publish_board",
             action="store_const",
@@ -145,19 +161,21 @@ class VersionTwoConfig:
 
         self.output_file = parsed_args.output_file
         self.temp_dir = parsed_args.temp_dir
-        self.include_team = parsed_args.include_team
+        self.project = parsed_args.include_project
         self.include_user = parsed_args.include_user
         self.include_repository = parsed_args.include_repository
         self.include_organization = parsed_args.include_organization
         self.include_organization_repository = parsed_args.include_organization_repository
         self.include_label = parsed_args.include_label
-        self.exclude_team = parsed_args.exclude_team
+        self.include_team = parsed_args.include_team
+        self.exclude_project = parsed_args.exclude_project
         self.exclude_user = parsed_args.exclude_user
         self.exclude_repository = parsed_args.exclude_repository
         self.exclude_organization = parsed_args.exclude_organization
         self.exclude_organization_repository = parsed_args.exclude_organization_repository
         self.exclude_label = parsed_args.exclude_label
         self.publish_board = parsed_args.publish_board
+        self.exclude_team = parsed_args.exclude_team
 
     def init_logger(self):
         logging.basicConfig(level=self.LOG_LEVEL, format=self.LOG_FORMAT)
@@ -169,16 +187,18 @@ class VersionTwoConfig:
         logging.info("Configuration:")
         logging.info(f"Output File: {self.output_file}")
         logging.info(f"Temporary Directory: {self.temp_dir}")
-        logging.info(f"Include Team: {self.include_team}")
+        logging.info(f"Include Project: {self.include_project}")
         logging.info(f"Include User: {self.include_user}")
         logging.info(f"Include Repository: {self.include_repository}")
         logging.info(f"Include Organization: {self.include_organization}")
         logging.info(f"Include Organization/Repository: {self.include_organization_repository}")
         logging.info(f"Include Label: {self.include_label}")
-        logging.info(f"Exclude Team: {self.exclude_team}")
+        logging.info(f"Include Team: {self.include_team}")
+        logging.info(f"Exclude Project: {self.exclude_project}")
         logging.info(f"Exclude User: {self.exclude_user}")
         logging.info(f"Exclude Repository: {self.exclude_repository}")
         logging.info(f"Exclude Organization: {self.exclude_organization}")
         logging.info(f"Exclude Organization/Repository: {self.exclude_organization_repository}")
         logging.info(f"Exclude Label: {self.exclude_label}")
         logging.info(f"Publish Board: {self.publish_board}")
+        logging.info(f"Exclude Team: {self.exclude_team}")

--- a/src/version2query.py
+++ b/src/version2query.py
@@ -222,12 +222,12 @@ class Version2Query:
 # This main method is used for testing out the version2query class
 def main():
   """The primary method for the version2query.py script."""
-  teams:list = input("Enter team name(s) to filter projects: ").split(",")
+  project_names:list = input("Enter team name(s) to filter projects: ").split(",")
   test_temp_dir:Path = Path(f"tmp.dir")
   test_output_file:str = f"output.items.json"
   
   query = Version2Query(temp_dir=test_temp_dir, output_file=test_output_file)
-  query.filters.include_teams = teams
+  query.filters.include_projects = project_names
   if not query.process():
     print("[red]Processing failed.[/red]")
     raise RunTimeError("Processing failed.")

--- a/version2.py
+++ b/version2.py
@@ -13,18 +13,20 @@ def main():
 
     # Get parameters for filters
     filters:dict[str,list[str]] = {
-      "include_teams":                     config.include_team,
+      "include_projects":                  config.include_project,
       "include_users":                     config.include_user,
       "include_repositories":              config.include_repository,
       "include_organizations":             config.include_organization,
       "include_organization_repositories": config.include_organization_repository,
       "include_labels":                    config.include_label,
-      "exclude_teams":                     config.exclude_team,
+      "include_teams":                     config.include_team,
+      "exclude_projects":                  config.exclude_project,
       "exclude_users":                     config.exclude_user,
       "exclude_repositories":              config.exclude_repository,
       "exclude_organizations":             config.exclude_organization,
       "exclude_organization_repositories": config.exclude_organization_repository,
-      "exclude_label":                     config.exclude_label
+      "exclude_label":                     config.exclude_label,
+      "exclude_teams":                     config.exclude_team
     }
 
     query:VersionTwoQuery = Version2Query(temp_dir=temp_dir, output_file=output_file)


### PR DESCRIPTION
**Description**:

The flag for include teams was misleading. We are actually filtering on project board name. Change the CLI to reflect that.

**Related Issue(s)**:

Closes #76